### PR TITLE
Branch options for `checkout` command

### DIFF
--- a/lib/flight_plan_cli/commands/checkout.rb
+++ b/lib/flight_plan_cli/commands/checkout.rb
@@ -7,6 +7,7 @@ module FlightPlanCli
       def initialize(issue_no, options)
         @issue_no = issue_no
         @base_branch = options["base"]
+        @branch_prefix = options["prefix"]
         @fetched = false
       end
 
@@ -19,7 +20,7 @@ module FlightPlanCli
 
       private
 
-      attr_reader :issue_no, :base_branch
+      attr_reader :issue_no, :base_branch, :branch_prefix
 
       def local_branch_for_issue
         issue_branches = local_branches.map(&:name).grep(/##{issue_no}[^0-9]/)
@@ -57,7 +58,7 @@ module FlightPlanCli
       end
 
       def branch_name(branch)
-        "feature/##{branch['ticket']['remote_number']}-" +
+        "#{branch_prefix}/##{branch['ticket']['remote_number']}-" +
           branch['ticket']['remote_title']
             .gsub(/\([^)]*\)/, '') # remove everything inside brackets
             .match(/^.{0,60}\b/)[0] # take the first 60 chars (finish on word boundry)

--- a/lib/flight_plan_cli/commands/checkout.rb
+++ b/lib/flight_plan_cli/commands/checkout.rb
@@ -4,8 +4,9 @@ module FlightPlanCli
       include FlightPlanCli::Clients::Git
       include FlightPlanCli::Clients::FlightPlan
 
-      def initialize(issue_no)
+      def initialize(issue_no, options)
         @issue_no = issue_no
+        @base_branch = options["base"]
         @fetched = false
       end
 
@@ -18,7 +19,7 @@ module FlightPlanCli
 
       private
 
-      attr_reader :issue_no
+      attr_reader :issue_no, :base_branch
 
       def local_branch_for_issue
         issue_branches = local_branches.map(&:name).grep(/##{issue_no}[^0-9]/)
@@ -49,9 +50,9 @@ module FlightPlanCli
         return false unless branches.count == 1
 
         branch_name = branch_name(branches.first)
-        git.checkout('master')
+        git.checkout(base_branch)
         git.pull
-        puts "Creating new branch #{branch_name} from master".green
+        puts "Creating new branch #{branch_name} from #{base_branch}".green
         git.branch(branch_name).checkout
       end
 

--- a/lib/flight_plan_cli/initializer.rb
+++ b/lib/flight_plan_cli/initializer.rb
@@ -9,8 +9,9 @@ module FlightPlanCli
     end
 
     desc 'checkout ISSUE_NO', 'checkout a branch for ISSUE_NO'
+    option :base, desc: 'base branch for the new branch', aliases: :b, default: 'master'
     def checkout(issue_no)
-      Commands::Checkout.new(issue_no).process
+      Commands::Checkout.new(issue_no, options).process
     end
 
     map co: :checkout

--- a/lib/flight_plan_cli/initializer.rb
+++ b/lib/flight_plan_cli/initializer.rb
@@ -10,6 +10,7 @@ module FlightPlanCli
 
     desc 'checkout ISSUE_NO', 'checkout a branch for ISSUE_NO'
     option :base, desc: 'base branch for the new branch', aliases: :b, default: 'master'
+    option :prefix, desc: 'prefix for the new branch', aliases: :p, default: 'feature'
     def checkout(issue_no)
       Commands::Checkout.new(issue_no, options).process
     end


### PR DESCRIPTION
Adds two new options to the `checkout` command

- `--prefix` or `-p` to change the `feature` branch name prefix to something else (`bug` etc.)
- `--base` or `-b` to change the base branch a new branch is created from

Defaults of `feature` for the prefix and `master` for the base branch are still used if the above options are not specified.